### PR TITLE
Update travis with OS X configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,47 @@
 language: cpp
-compiler:
-    - gcc
 sudo: required
 dist: trusty
-branches:
-  only:
-    - master
+
+addons:
+  apt:
+    packages:
+      - doxygen
+      - libboost-context-dev
+      - libboost-system-dev
+      - libboost-thread-dev
+      - libcairo2-dev
+      - libglew-dev
+      - libglm-dev
+      - libpotrace-dev
+# TODO: https://github.com/travis-ci/apt-package-whitelist/issues/417
+#     - libwxgtk3.0-0
+
+matrix:
+  include:
+    - compiler: gcc
+    - compiler: clang
+    - os: osx
+      compiler: clang
+
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libbz2-dev libcairo2-dev libglew-dev libwxgtk3.0-dev libglm-dev libboost-all-dev libpotrace-dev
-install: true
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        brew update;
+        brew install cairo glew glm potrace wxmac;
+      fi
+    # TODO: Remove once packages are whitelisted to use containerized env.
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        sudo apt-get update -qq;
+        sudo apt-get install -y libwxgtk3.0-dev;
+      fi
+
 script:
-  - cd $TRAVIS_BUILD_DIR
-  - mkdir build
-  - cd build
-  - cmake ..
-  - make -j4
+    # TODO: cmake should contain default version and override if needed
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        export EXTRA_ARGS=-DCMAKE_OSX_DEPLOYMENT_TARGET=10.10;
+      fi
+    - mkdir build && cd build && cmake $EXTRA_ARGS .. && make
+
+install: true
+
+notifications:
+    email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,38 @@ perform_feature_checks()
 # Set flags for GCC, or treat llvm as GCC
 #================================================
 
+include(CheckCXXCompilerFlag)
+
+# wxWidgets 3.0 requires -std=c++11 or -std=c++0x support
+# TODO: This should be reported upstream and fixed there
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if( COMPILER_SUPPORTS_CXX11 )
+    if( CMAKE_COMPILER_IS_GNUCXX )
+        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+    else()
+        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
+elseif(COMPILER_SUPPORTS_CXX0X)
+    if( CMAKE_COMPILER_IS_GNUCXX )
+        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x")
+    else()
+        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+    endif()
+else()
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11/C++0x support. Please use a different C++ compiler.")
+endif()
+
+check_cxx_compiler_flag(-Wno-unused-local-typedefs, HAS_OPT_UNUSED_LOCAL_TYPEDEFS)
+if ( HAS_OPT_UNUSED_LOCAL_TYPEDEFS )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
+endif()
+check_cxx_compiler_flag(-Wno-strinct-aliasing, HAS_OPT_STRICT_ALIASING)
+if ( HAS_OPT_STRICT_ALIASING )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-aliasing" )
+endif()
+
+
 if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
 
     execute_process( COMMAND ${CMAKE_C_COMPILER} -dumpversion
@@ -201,12 +233,6 @@ if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
         endif()
 
     endif()
-
-    # quiet GCC while in boost
-    if( GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8 OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
-        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs" )
-    endif()
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-aliasing" )
 
     if( APPLE )
 


### PR DESCRIPTION
Improve travis script to cover 3 builds:

* Linux with gcc
* Linux with clang
* OS X with clang (targeting OS X version 10.10)